### PR TITLE
Refactor exceptions

### DIFF
--- a/oneapi/__init__.py
+++ b/oneapi/__init__.py
@@ -159,7 +159,7 @@ class AbstractOneApiClient:
 
         if self.raise_exception and not result.is_success():
             message = "{0}: {1} [{2}]".format(result.exception.message_id, result.exception.text, result.exception.variables)
-            raise Exception(message)
+            raise OneApiError(message)
 
         return result
 
@@ -219,7 +219,7 @@ class SmsClient(AbstractOneApiClient):
             if sms.callback_data:
                 params['callbackData'] = sms.callback_data
         else:
-            raise Exception("invalid asked data format (supported url or json")
+            raise ValueError("invalid asked data format (supported url or json")
 
         is_success, result = self.execute_POST(
                 '/1/smsmessaging/outbound/{0}/requests'.format(sms.sender_address),
@@ -294,7 +294,7 @@ class SmsClient(AbstractOneApiClient):
                     'filterCriteria' : sms.filter_criteria
                     }
         else:
-            raise Exception("invalid asked data format (supported url or json")
+            raise ValueError("invalid asked data format (supported url or json")
 
         is_success, result = self.execute_POST(
                 '/1/smsmessaging/outbound/'
@@ -345,7 +345,7 @@ class SmsClient(AbstractOneApiClient):
                 params['client_correlator'] = sms.client_correlator
                 #resourceURL
         else:
-            raise Exception("invalid asked data format (supported url or json")
+            raise ValueError("invalid asked data format (supported url or json")
 
         is_success, result = self.execute_POST(
                 '/1/smsmessaging/inbound/subscriptions',

--- a/oneapi/exceptions.py
+++ b/oneapi/exceptions.py
@@ -1,0 +1,2 @@
+class OneApiError(Exception):
+    pass

--- a/oneapi/http.py
+++ b/oneapi/http.py
@@ -56,7 +56,7 @@ def urlencode_params(params):
 
 def execute_request(method, url, data=None, headers=None, data_format=None):
     if not method in VALID_METHODS:
-        raise Exception('Invalid method %s' % method)
+        raise ValueError('Invalid method %s' % method)
 
     mod_logging.debug('%s to %s with %s', method, url, data)
 

--- a/oneapi/utils.py
+++ b/oneapi/utils.py
@@ -4,9 +4,9 @@ import random as mod_random
 
 def get_random_string(length, chars):
     if not length:
-        raise Exception('Invalid random string length: {0}'.format(length))
+        raise TypeError('Invalid random string length: {0}'.format(length))
     if not chars:
-        raise Exception('Invalid random chars: {0}'.format(chars))
+        raise TypeError('Invalid random chars: {0}'.format(chars))
 
     result = ''
 


### PR DESCRIPTION
This refactor should help with proper error handling in applications
that use this library.

This patch introduces `OneApiError` which is available for applications
to catch rather than catching `Exception` which could come from
anywhere.